### PR TITLE
Tradução no IZT - Header

### DIFF
--- a/src/components/features/Footer/Footer.jsx
+++ b/src/components/features/Footer/Footer.jsx
@@ -3,6 +3,7 @@ import { BsInstagram, BsWhatsapp } from 'react-icons/bs';
 import { HiOutlineMail } from 'react-icons/hi';
 import { useLocation, useNavigate } from 'react-router-dom';
 
+import { useGlobalLanguage } from '../../../stores/globalLanguage';
 import { Logo } from '../../common';
 import {
   Container,
@@ -17,9 +18,15 @@ import {
   ButtonMobile,
   SectionGoTo,
   ContactButton,
+  Centralize,
 } from './Styles';
+import { TranslateText } from './translations';
 
 export default function Footer() {
+  // Translation
+  const { globalLanguage } = useGlobalLanguage();
+  const translations = TranslateText({ globalLanguage });
+
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -55,24 +62,21 @@ export default function Footer() {
         <LogoSection>
           <Logo />
         </LogoSection>
-        <Text>
-          Inovação, tecnologia, precisão, qualidade e sustentabilidade.
-        </Text>
+        <Text> {translations.IZTDescription} </Text>
       </SideContainer>
       <MiddleContainer>
-        <Tittle>Contato</Tittle>
-        <Text>
-          Entre em contato agora para sanar todas dúvidas sobre nossos produtos,
-          nossos softwares ou nossos cursos.
-        </Text>
+        <Tittle>{translations.contact}</Tittle>
+        <Text>{translations.contactDescription}</Text>
 
         <ContactButton onClick={handleContactButtonClick}>
-          Fale Conosco
+          {translations.button}
         </ContactButton>
       </MiddleContainer>
 
       <SideContainer>
-        <Tittle>Nossas Redes</Tittle>
+        <Tittle>
+          <Centralize>{translations.socialMedia}</Centralize>
+        </Tittle>
         <SocialMedias>
           <SocialMediaButton href="https://cpejr.com/">
             <BsInstagram size={30} />
@@ -93,14 +97,14 @@ export default function Footer() {
 
         <ButtonMobile>
           <ContactButton onClick={handleContactButtonClick}>
-            Fale Conosco
+            {translations.button}
           </ContactButton>
         </ButtonMobile>
 
         <SectionGoTo>
-          <Tittle>Ir para</Tittle>
-          <GoTo to="/catalogo">Produtos</GoTo>
-          <GoTo to="/curso">Cursos</GoTo>
+          <Tittle>{translations.goTo}</Tittle>
+          <GoTo to="/catalogo">{translations.products}</GoTo>
+          <GoTo to="/curso">{translations.courses}</GoTo>
           <GoTo to="/software">Software</GoTo>
         </SectionGoTo>
       </SideContainer>

--- a/src/components/features/Footer/Styles.js
+++ b/src/components/features/Footer/Styles.js
@@ -206,3 +206,7 @@ export const ContactButton = styled.button`
     max-width: 95%;
   }
 `;
+
+export const Centralize = styled.div`
+  text-align: center;
+`;

--- a/src/components/features/Footer/translations.js
+++ b/src/components/features/Footer/translations.js
@@ -1,0 +1,56 @@
+// eslint-disable-next-line import/prefer-default-export
+export function TranslateText({ globalLanguage }) {
+  let IZTDescription;
+  let contact;
+  let contactDescription;
+  let button;
+  let socialMedia;
+  let goTo;
+  let products;
+  let courses;
+
+  if (globalLanguage === 'EN') {
+    IZTDescription =
+      'Innovation, technology, precision, quality and sustainability.';
+    contact = 'Contact';
+    contactDescription =
+      'Get in touch now to answer any questions about our products, our software or our courses.';
+    button = 'Contact us';
+    socialMedia = 'Our social networks';
+    goTo = 'Go to';
+    products = 'Products';
+    courses = 'Courses';
+  } else if (globalLanguage === 'PT') {
+    IZTDescription =
+      'Inovação, tecnologia, precisão, qualidade e sustentabilidade.';
+    contact = 'Contato';
+    contactDescription =
+      'Entre em contato agora para sanar todas dúvidas sobre nossos produtos, nossos softwares ou nossos cursos.';
+    button = 'Fale Conosco';
+    socialMedia = 'Nossas Redes';
+    goTo = 'Ir para';
+    products = 'Produtos';
+    courses = 'Cursos';
+  } else if (globalLanguage === 'DE') {
+    IZTDescription =
+      'Innovation, Technologie, Präzision, Qualität und Nachhaltigkeit.';
+    contact = 'Kontakt';
+    contactDescription =
+      'Nehmen Sie jetzt Kontakt auf, um Fragen zu unseren Produkten, unserer Software oder unseren Kursen zu beantworten.';
+    button = 'Kontaktiere uns';
+    socialMedia = 'Unsere sozialen Netzwerke';
+    goTo = 'Gehe zu';
+    products = 'Produkte';
+    courses = 'Kurse';
+  }
+  return {
+    IZTDescription,
+    contact,
+    contactDescription,
+    button,
+    socialMedia,
+    goTo,
+    products,
+    courses,
+  };
+}


### PR DESCRIPTION
Atualmente nossa dev, Amanda, chegou a fazer a tradução da página HOME e também na página de produtos do IZT. Sendo assim, cabe agora fazer o resto do trabalho nas outras páginas. 

Para fazer isso, valer-nos-emos de lógica de programação, e não de alguma biblioteca específica.  Deverá ser criado um arquivo chamado translations.js, onde ele vai colocar os operadores ternários e a lógica por trás da tradução, para saber a linguagem selecionada.

Além disso, será necessário adicionar o Header nessa página, pois ele não estava lendo algumas variáveis a princípio. Sendo assim, cabe o alinhamento constante com a DEV. 

Para traduzir, basta jogar as coisas no chat GPT, ele traduz com uma precisão assustadora. 

Nessa tarefa, será traduzido o header.  

Dúvidas, comentar com os gerentes.