### PR TITLE
Corrigir Bug de Tradução

### DIFF
--- a/src/stores/globalLanguage.jsx
+++ b/src/stores/globalLanguage.jsx
@@ -1,11 +1,22 @@
-import React, { createContext, useContext, useMemo, useState } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  useEffect,
+} from 'react';
 
 import PropTypes from 'prop-types';
 
 const LanguageContext = createContext();
 
 export function LanguageProvider({ children }) {
-  const [globalLanguage, setGlobalLanguage] = useState('PT');
+  const storedLanguage = localStorage.getItem('globalLanguage');
+  const [globalLanguage, setGlobalLanguage] = useState(storedLanguage || 'PT');
+
+  useEffect(() => {
+    localStorage.setItem('globalLanguage', globalLanguage);
+  }, [globalLanguage]);
 
   const value = useMemo(
     () => ({ globalLanguage, setGlobalLanguage }),


### PR DESCRIPTION
Agora que as traduções do IZT estão ficando prontas, deparamo-nos com um novo Bug: ao recarregar a página, a linguagem selecionada não se mantém. 

O intuito dessa tarefa é encontrar esse bug e corrigi-lo.