### PR TITLE
Tradução dos Acessos Negados

### DIFF
--- a/src/pages/AccessDenied/AccessDenied.jsx
+++ b/src/pages/AccessDenied/AccessDenied.jsx
@@ -1,13 +1,28 @@
 import PropTypes from 'prop-types';
 
 import { FormsContact } from '../../components/features';
+import { useGlobalLanguage } from '../../stores/globalLanguage';
 import { Container, UpperDiv, TextDiv } from './Styles';
 import { contentOptions } from './utils';
+import { contentOptionsDE } from './utilsDE';
+import { contentOptionsEN } from './utilsEN';
 
 export default function AccessDenied({ content }) {
   // texts prop define if the user tried to access the software page or the course page
   // texts is required and can be only course or software
-  const pageContent = contentOptions[content];
+  const { globalLanguage } = useGlobalLanguage();
+  let pageContent;
+  switch (globalLanguage) {
+    case 'EN':
+      pageContent = contentOptionsEN[content];
+      break;
+    case 'DE':
+      pageContent = contentOptionsDE[content];
+      break;
+    default:
+      pageContent = contentOptions[content];
+  }
+
   return (
     <Container>
       <UpperDiv image={pageContent.imageURL}>

--- a/src/pages/AccessDenied/utilsDE.js
+++ b/src/pages/AccessDenied/utilsDE.js
@@ -1,0 +1,15 @@
+/* eslint-disable import/prefer-default-export */
+export const contentOptionsDE = {
+  course: {
+    title: 'Sie haben noch keinen Zugriff auf unseren Kurs!',
+    text: 'Es tut uns leid, Ihnen mitteilen zu müssen, dass Ihnen der Zugriff auf den Kurs verweigert wurde. Dieser Kurs ist ausschließlich für diejenigen reserviert, die sich im Voraus angemeldet haben. Wir stehen jedoch zur Verfügung, um Ihnen beim Erwerb dieses Kurses und anderer Produkte, die für Sie interessant sein könnten, zu helfen. Bitte kontaktieren Sie uns über das unten stehende Formular, um ihn zu erwerben.',
+    formTitle: 'Holen Sie sich unseren Kurs!',
+    imageURL: 'src/assets/accessDeniedPage/BGCourse.png',
+  },
+  software: {
+    title: 'Sie haben noch keinen Zugriff auf unsere Software!',
+    text: 'Es tut uns leid, Ihnen mitteilen zu müssen, dass Ihnen der Zugriff auf unsere Software verweigert wurde. Diese Software ist ausschließlich für diejenigen reserviert, die sich im Voraus angemeldet haben. Wir stehen jedoch zur Verfügung, um Ihnen beim Erwerb dieser Software und anderer Produkte, die für Sie interessant sein könnten, zu helfen. Bitte kontaktieren Sie uns über das unten stehende Formular, um Zugang zu erhalten.',
+    formTitle: 'Erhalten Sie Zugang!',
+    imageURL: 'src/assets/accessDeniedPage/BGSoftware.jpg',
+  },
+};

--- a/src/pages/AccessDenied/utilsEN.js
+++ b/src/pages/AccessDenied/utilsEN.js
@@ -1,0 +1,15 @@
+/* eslint-disable import/prefer-default-export */
+export const contentOptionsEN = {
+  course: {
+    title: 'You do not have access to our course yet!',
+    text: 'We regret to inform you that your access to the course has been denied. This course is exclusive to those who have pre-registered. However, we are here to help you acquire this course and other products that may be of interest to you. Please contact us through the form below to purchase it.',
+    formTitle: 'Get Our Course!',
+    imageURL: 'src/assets/accessDeniedPage/BGCourse.png',
+  },
+  software: {
+    title: 'You do not have access to our software yet!',
+    text: 'We regret to inform you that your access to our software has been denied. This software is exclusive to those who have pre-registered. However, we are here to help you acquire this software and other products that may be of interest to you. Please contact us through the form below to purchase access.',
+    formTitle: 'Get Access!',
+    imageURL: 'src/assets/accessDeniedPage/BGSoftware.jpg',
+  },
+};


### PR DESCRIPTION
Atualmente nossa dev, Amanda, chegou a fazer a tradução da página HOME e também na página de produtos do IZT. Sendo assim, cabe agora fazer o resto do trabalho nas outras páginas. 

Para fazer isso, valer-nos-emos de lógica de programação, e não de alguma biblioteca específica.  Deverá ser criado um arquivo chamado translations.js, onde ele vai colocar os operadores ternários e a lógica por trás da tradução, para saber a linguagem selecionada.

Além disso, será necessário adicionar o Header nessa página, pois ele não estava lendo algumas variáveis a princípio. Sendo assim, cabe o alinhamento constante com a DEV. 

Para traduzir, basta jogar as coisas no chat GPT, ele traduz com uma precisão assustadora. 

Nessa tarefa, será traduzida as páginas de acesso negado.  

Apenas é válido se atentar ao fato de que nessas páginas há formulários, eles também precisam ser traduzidos. 

Dúvidas, comentar com os gerentes.