### PR TITLE
Linkagem outputs Profile Analysis na seção de Relatórios

### DIFF
--- a/src/components/features/Graphic/ProfileAnalysisGraph.jsx
+++ b/src/components/features/Graphic/ProfileAnalysisGraph.jsx
@@ -24,7 +24,7 @@ export default function ProfileAnalysisGraph({ data }) {
           title: 'Y Axis',
         },
       }}
-      style={{ width: '40%', height: '300px' }}
+      style={{ width: '100%', height: '300px' }}
       useResizeHandler="true"
     />
   );

--- a/src/components/features/PDF/ProfileAnalysisPDF.jsx
+++ b/src/components/features/PDF/ProfileAnalysisPDF.jsx
@@ -225,6 +225,35 @@ export default function ProfileAnalysisPDF({ data }) {
               </Text>
               <Text style={styles.item}>Sobremetal: {data?.allowance} mm</Text>
             </div>
+
+            <Text style={styles.section}>Dados de Saída</Text>
+
+            <div style={styles.space}>
+              <Text style={styles.item}>
+                Rotação do rebolo de arraste (nr): {data?.radragRotationnr} rps
+              </Text>
+              <Text style={styles.item}>
+                Velocidade periférica da peça (vp): {data?.peripheralSpeed} m/s
+              </Text>
+              <Text style={styles.item}>
+                Velocidade de passagem da peça (vfa): {data?.passingSpeed} m/min
+              </Text>
+              <Text style={styles.item}>
+                Quantidade de peça (Qp): {data?.partQuantity}
+              </Text>
+              <Text style={styles.item}>
+                Tempo de ciclo (tc): {data?.cycleTime} min/pc
+              </Text>
+              <Text style={styles.item}>
+                Nr. revoluções da peça: {data?.revolution} min/pc
+              </Text>
+              <Text style={styles.item}>
+                Taxa de remoção: {data?.removeRate} mm3/mm.s
+              </Text>
+              <Text style={styles.item}>
+                Espessura de corte: {data?.cutThickness} mm
+              </Text>
+            </div>
           </div>
           <div style={styles.collumn2}>
             {/* <Image style={styles.image} src={data?.graphImage[0].url} /> */}

--- a/src/components/features/ProfileAnalysisReport/ProfileAnalysisReport.jsx
+++ b/src/components/features/ProfileAnalysisReport/ProfileAnalysisReport.jsx
@@ -25,6 +25,8 @@ import {
   ReportName,
   DashedBar,
   ModalStyle,
+  RowDiagram,
+  Diagram,
 } from './Styles';
 import { TranslateText } from './translations';
 
@@ -203,12 +205,53 @@ export default function ProfileAnalysisReport({
             </DataColumn>
           </Row>
         </Columns>
-        <div>
-          <Title>{translations.tfCenterlessGrindingGap}</Title>
-          <ProfileAnalysisGraph
-            data={data?.profileAnalysisDiagram?.retificationCenterlessDiagram}
-          />
-        </div>
+        <RowDiagram>
+          <Diagram>
+            <Title>{translations.tfCenterlessGrindingGap}</Title>
+            <ProfileAnalysisGraph
+              data={data?.profileAnalysisDiagram?.retificationCenterlessDiagram}
+            />
+          </Diagram>
+          <DashedBar />
+          <DataColumn>
+            <Title>{translations.outputData}</Title>
+            <DataContainer>
+              <DataRow>
+                <Label>{translations.radragRotationnr}: (nr)</Label>
+                <Data>{data?.radragRotationnr} rps</Data>
+              </DataRow>
+              <DataRow>
+                <Label>{translations.peripheralSpeed} (vp):</Label>
+                <Data>{data?.peripheralSpeed} m/s</Data>
+              </DataRow>
+              <DataRow>
+                <Label>{translations.passingSpeed} (vfa):</Label>
+                <Data>{data?.passingSpeed} m/min</Data>
+              </DataRow>
+              <DataRow>
+                <Label>{translations.partQuantity} (Qp):</Label>
+                <Data>{data?.partQuantity} </Data>
+              </DataRow>
+              <DataRow>
+                <Label>{translations.cycleTime} (tc):</Label>
+                <Data>{data?.cycleTime} min/pc</Data>
+              </DataRow>
+              <DataRow>
+                <Label>{translations.revolution}:</Label>
+                <Data>{data?.revolution} min/pc</Data>
+              </DataRow>
+              <DataRow>
+                <Label>{translations.removeRate}:</Label>
+                <Data>{data?.removeRate} mm3/mm.s</Data>
+              </DataRow>
+              <DataRow>
+                <Label>{translations.cutThickness}:</Label>
+                <Data>{data?.cutThickness} mm</Data>
+              </DataRow>
+            </DataContainer>
+          </DataColumn>
+        </RowDiagram>
+
         <ButtonRow>
           <button type="button" onClick={saveFile}>
             {translations.download}

--- a/src/components/features/ProfileAnalysisReport/Styles.js
+++ b/src/components/features/ProfileAnalysisReport/Styles.js
@@ -34,8 +34,8 @@ export const DataColumn = styled.div`
   gap: 0.5rem;
   width: 50%;
   height: 100%;
-  max-height: 25rem;
-  max-width: 28rem;
+  max-height: 26rem;
+  max-width: 29rem;
   /* margin: auto; erro na posição do título /*
   /*margin: 0.5rem;  Adicione o valor de margem que desejar (estava dando erro no alinhamento do pontilhado) */
   padding: 0.5rem; /* Opcional: Adiciona preenchimento interno para a div */
@@ -51,6 +51,19 @@ export const DataColumn = styled.div`
 export const Row = styled.div`
   display: flex;
   flex-direction: row;
+`;
+export const RowDiagram = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 80%;
+  gap: 1rem;
+  justify-content: center;
+`;
+export const Diagram = styled.div`
+  width: 100%;
+  svg {
+    width: 100%;
+  }
 `;
 
 export const DataRow = styled.div`
@@ -76,10 +89,10 @@ export const DataContainer = styled.div`
   gap: 0.5rem;
   width: 100%;
   max-height: 25rem;
-  max-width: 28rem;
-  padding-left: 1.5rem;
+  max-width: 29rem;
+  padding-left: 0rem;
   @media (max-width: 1350px) {
-    max-height: 25rem;
+    max-height: 26rem;
   }
 `;
 

--- a/src/components/features/ProfileAnalysisReport/translations.js
+++ b/src/components/features/ProfileAnalysisReport/translations.js
@@ -34,6 +34,15 @@ export function TranslateText({ globalLanguage }) {
   let dresserHeight;
   let dresserPosition;
   let tfCenterlessGrindingGap;
+  let outputData;
+  let radragRotationnr;
+  let peripheralSpeed;
+  let passingSpeed;
+  let partQuantity;
+  let cycleTime;
+  let revolution;
+  let removeRate;
+  let cutThickness;
 
   if (globalLanguage === 'EN') {
     analysisData = 'Analysis Data';
@@ -70,6 +79,15 @@ export function TranslateText({ globalLanguage }) {
     dresserHeight = 'Dresser Height';
     dresserPosition = 'Dresser Position';
     tfCenterlessGrindingGap = 'Through-Feed Centerless Grinding Gap';
+    outputData = 'Output Data';
+    radragRotationnr = 'Grinding wheel rotation';
+    peripheralSpeed = 'Peripheral speed of the workpiece';
+    passingSpeed = 'Workpiece feed speed';
+    partQuantity = 'Quantity of pieces';
+    cycleTime = 'Cycle time';
+    revolution = 'Workpiece revolutions';
+    removeRate = 'Removal rate';
+    cutThickness = 'Cutting thickness';
   } else if (globalLanguage === 'PT') {
     analysisData = 'Dados da Análise';
     machineData = 'Dados da Máquina';
@@ -105,6 +123,15 @@ export function TranslateText({ globalLanguage }) {
     dresserHeight = 'Altura do dressador';
     dresserPosition = 'Posição do dressador';
     tfCenterlessGrindingGap = 'Vão de retificação centerless de passagem';
+    outputData = 'Dados de saída';
+    radragRotationnr = 'Rotação do rebolo de arraste';
+    peripheralSpeed = 'Velocidade periférica da peça';
+    passingSpeed = 'Velocidade de passagem da peça';
+    partQuantity = 'Quantidade de peças';
+    cycleTime = 'Tempo de ciclo';
+    revolution = 'Nr. revoluções da peça';
+    removeRate = 'Taxa de remoção';
+    cutThickness = 'Espessura de corte';
   } else if (globalLanguage === 'DE') {
     analysisData = 'Analyse-Daten';
     machineData = 'Maschinendaten';
@@ -140,6 +167,15 @@ export function TranslateText({ globalLanguage }) {
     dresserHeight = 'Dresser-Höhe';
     dresserPosition = 'Dresser-Position';
     tfCenterlessGrindingGap = 'Durchlauf-Centerless-Schleifspalt';
+    outputData = 'Ausgabedaten';
+    radragRotationnr = 'Schleifscheibendrehung';
+    peripheralSpeed = 'Umfangsgeschwindigkeit des Werkstücks';
+    passingSpeed = 'Werkstückvorschubgeschwindigkeit';
+    partQuantity = 'Werkstückmenge';
+    cycleTime = 'Zykluszeit';
+    revolution = 'Werkstückumdrehungen';
+    removeRate = 'Abtragsrate';
+    cutThickness = 'Schnittdicke';
   }
   return {
     analysisData,
@@ -176,5 +212,14 @@ export function TranslateText({ globalLanguage }) {
     dresserHeight,
     dresserPosition,
     tfCenterlessGrindingGap,
+    outputData,
+    radragRotationnr,
+    peripheralSpeed,
+    passingSpeed,
+    partQuantity,
+    cycleTime,
+    revolution,
+    removeRate,
+    cutThickness,
   };
 }

--- a/src/pages/ProfileAnalysis/ProfileAnalysis.jsx
+++ b/src/pages/ProfileAnalysis/ProfileAnalysis.jsx
@@ -197,7 +197,6 @@ export default function ProfileAnalysis() {
 
   useEffect(() => {}, [formDataStorage]);
   const user = useAuthStore((state) => state.auth?.user);
-
   const {
     handleSubmit: save,
     register: register2,
@@ -390,8 +389,8 @@ export default function ProfileAnalysis() {
                 'Centerless de Passagem' ? (
                   <>
                     <Text2>
-                      {translations.removalRate} (Qw’): {Maths?.remove || '___'}{' '}
-                      mm3/mm.s
+                      {translations.removalRate} (Qw’):{' '}
+                      {Maths?.removeRate || '___'} mm3/mm.s
                     </Text2>
                     <Text2>
                       {' '}

--- a/src/pages/ProfileAnalysis/ProfileMaths.js
+++ b/src/pages/ProfileAnalysis/ProfileMaths.js
@@ -22,14 +22,14 @@ export default function ProfileMaths(InputDataStorage) {
   const revolution =
     rcEffectiveLengthMath /
     (Math.PI * diameterMath * Math.tan(raInclinationMath));
-  const remove =
+  const removeRate =
     (allowanceMath *
       passingSpeed *
       Math.PI *
       diameterMath *
       electiveLengthMath) /
     (2 * rcEffectiveLengthMath * totalLengthMath);
-  const cutThickness = remove / speedPeripheralMath;
+  const cutThickness = removeRate / speedPeripheralMath;
   return {
     radragRotationnr,
     peripheralSpeed,
@@ -37,7 +37,7 @@ export default function ProfileMaths(InputDataStorage) {
     partQuantity,
     cycleTime,
     revolution,
-    remove,
+    removeRate,
     cutThickness,
   };
 }


### PR DESCRIPTION
Na Sprint passada, foi realizada uma tarefa na qual fazia com que os dados de saída aparecessem na página de software de Análise de Perfil. Esses dados já estão sendo salvos no back-end. Agora, vocês devem fazer com que esses dados de saída apareçam tanto na seção de relatórios de Análise de Perfil, quanto no PDF gerado do mesmo.

Assim sendo, vocês devem adicionar esses outputs no front end do componente que mostra os dados do relatório de análise de perfil e posteriormente, realizar a linkagem.